### PR TITLE
Create personal homepage for Tao Hu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,219 @@
+:root {
+  --primary: #3d6ad6;
+  --accent: #f2b544;
+  --dark: #0b132b;
+  --light: #f8f9fc;
+  --text: #1f2d3d;
+}
+
+body {
+  font-family: 'Open Sans', sans-serif;
+  color: var(--text);
+  background-color: #ffffff;
+  scroll-behavior: smooth;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Lora', serif;
+  color: var(--dark);
+}
+
+.navbar {
+  background: rgba(11, 19, 43, 0.9);
+  backdrop-filter: blur(6px);
+  transition: background 0.3s ease-in-out;
+}
+
+.navbar .navbar-brand {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.navbar-nav .nav-link {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.navbar-nav .nav-link:hover,
+.navbar-nav .nav-link:focus {
+  color: #ffffff;
+}
+
+.hero {
+  position: relative;
+  padding: 180px 0 140px;
+  background: linear-gradient(115deg, rgba(11, 19, 43, 0.85), rgba(61, 106, 214, 0.75)),
+              url('../img/tao-hu.jpg') center/cover no-repeat;
+  color: #ffffff;
+}
+
+.hero .overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(11, 19, 43, 0.4);
+}
+
+.hero .container {
+  position: relative;
+  z-index: 1;
+}
+
+.hero h1 {
+  color: #ffffff;
+}
+
+.hero p {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.profile-card img {
+  max-width: 240px;
+  border: 6px solid rgba(255, 255, 255, 0.8);
+}
+
+.section-title {
+  font-size: 2.4rem;
+  margin-bottom: 2rem;
+  position: relative;
+  display: inline-block;
+}
+
+.section-title::after {
+  content: '';
+  display: block;
+  width: 80px;
+  height: 4px;
+  background: var(--primary);
+  margin-top: 12px;
+}
+
+.highlight-box {
+  background: linear-gradient(135deg, rgba(61, 106, 214, 0.1), rgba(242, 181, 68, 0.15));
+  border-left: 4px solid var(--primary);
+  padding: 1.5rem;
+  border-radius: 12px;
+}
+
+.highlight-box ul {
+  margin-bottom: 0;
+}
+
+.timeline {
+  position: relative;
+  margin: 2rem 0;
+  padding-left: 30px;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 12px;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(61, 106, 214, 0.2), rgba(11, 19, 43, 0.4));
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 2.5rem;
+}
+
+.timeline-marker {
+  position: absolute;
+  top: 6px;
+  left: -4px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 4px solid var(--primary);
+}
+
+.timeline-content {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+}
+
+.timeline-content h3 {
+  margin-bottom: 0.5rem;
+}
+
+.card {
+  border: none;
+  border-radius: 16px;
+  background: #ffffff;
+}
+
+.card-body {
+  padding: 2rem;
+}
+
+.card ul {
+  margin-bottom: 0;
+}
+
+.award-card,
+.skill-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.75rem;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+  border-top: 4px solid var(--primary);
+}
+
+.award-card h3,
+.skill-card h3 {
+  font-size: 1.3rem;
+  margin-bottom: 1rem;
+}
+
+.skill-card ul {
+  padding-left: 1.2rem;
+}
+
+.contact-info .btn {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  border-radius: 50px;
+  padding-inline: 1.8rem;
+}
+
+footer {
+  background: #f5f7fb;
+}
+
+@media (max-width: 991px) {
+  .hero {
+    padding: 160px 0 120px;
+  }
+
+  .profile-card img {
+    max-width: 200px;
+  }
+}
+
+@media (max-width: 767px) {
+  .navbar {
+    background: rgba(11, 19, 43, 0.95);
+  }
+
+  .timeline {
+    padding-left: 15px;
+  }
+
+  .timeline::before {
+    left: 6px;
+  }
+
+  .timeline-marker {
+    left: -8px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tao Hu | Personal Homepage</title>
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
+    <div class="container">
+      <a class="navbar-brand" href="#top">Tao Hu</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="#about">About</a></li>
+          <li class="nav-item"><a class="nav-link" href="#education">Education</a></li>
+          <li class="nav-item"><a class="nav-link" href="#research">Research</a></li>
+          <li class="nav-item"><a class="nav-link" href="#experience">Experience</a></li>
+          <li class="nav-item"><a class="nav-link" href="#honors">Honors</a></li>
+          <li class="nav-item"><a class="nav-link" href="#skills">Skills</a></li>
+          <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <header class="hero" id="top">
+    <div class="overlay"></div>
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-7">
+          <h1 class="display-4 fw-semibold">Optimization Enthusiast &amp; Aspiring Researcher</h1>
+          <p class="lead">I am Tao Hu, an undergraduate researcher driven by curiosity for mathematical optimization, stochastic processes, and numerical analysis. Currently studying mathematics at Xi’an Jiaotong University and as a visiting student at UC Berkeley, I explore how elegant theory powers practical algorithms.</p>
+          <a class="btn btn-outline-light btn-lg me-3" href="#contact">Get in touch</a>
+          <a class="btn btn-light btn-lg" href="#research">See my work</a>
+        </div>
+        <div class="col-lg-4 offset-lg-1 text-center text-lg-end mt-5 mt-lg-0">
+          <div class="profile-card">
+            <img src="img/tao-hu.jpg" class="img-fluid rounded-circle shadow" alt="Portrait of Tao Hu">
+            <p class="small text-muted mt-3">Photo courtesy of Tao Hu</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="about" class="py-5 bg-light">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-9">
+            <h2 class="section-title">Welcome!</h2>
+            <p class="fs-5">I am a mathematics major in the Honor Science Program at <strong>Xi’an Jiaotong University</strong>, currently ranking first in my cohort with a 4.19/4.3 GPA. In Spring 2025, I joined the <strong>Berkeley Global Access Program</strong> at UC Berkeley to dive deeper into graduate-level optimization and stochastic processes.</p>
+            <p class="fs-5">My research sits at the intersection of <strong>optimization theory</strong> and <strong>machine learning</strong>. I enjoy formulating elegant algorithms, experimenting with scientific computing tools, and sharing knowledge through teaching and mentorship.</p>
+            <div class="highlight-box mt-4">
+              <h3 class="h5 mb-3">Current Interests</h3>
+              <ul class="mb-0">
+                <li>Physics-informed neural networks and scientific machine learning</li>
+                <li>Stochastic and derivative-free optimization</li>
+                <li>Numerical methods for differential equations</li>
+                <li>Formalizing mathematics in proof assistants</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="education" class="py-5">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-10">
+            <h2 class="section-title">Education</h2>
+            <div class="timeline">
+              <div class="timeline-item">
+                <div class="timeline-marker"></div>
+                <div class="timeline-content">
+                  <h3>University of California, Berkeley</h3>
+                  <p class="text-muted mb-2">Berkeley Global Access • Jan. 2025 – Present</p>
+                  <p>Graduate coursework in Mathematical Programming, Applied Stochastic Process, Stochastic Optimization, and Numerical Solution of Differential Equations. GPA: 4.0/4.0.</p>
+                </div>
+              </div>
+              <div class="timeline-item">
+                <div class="timeline-marker"></div>
+                <div class="timeline-content">
+                  <h3>Xi’an Jiaotong University</h3>
+                  <p class="text-muted mb-2">Honor Science Program in Mathematics • Sept. 2022 – Present</p>
+                  <p>GPA: 4.19/4.3 (Rank 1/32). Completed advanced coursework in real and complex analysis, probability theory, topology, abstract algebra, numerical analysis, and dynamical systems.</p>
+                </div>
+              </div>
+              <div class="timeline-item">
+                <div class="timeline-marker"></div>
+                <div class="timeline-content">
+                  <h3>Xi’an Jiaotong University</h3>
+                  <p class="text-muted mb-2">Honor Youth Program (Special Class for the Gifted Young) • Aug. 2021 – Jun. 2022</p>
+                  <p>Ranked 1/40 in a rigorous accelerated curriculum designed for exceptional young scholars.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="research" class="py-5 bg-light">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-10">
+            <h2 class="section-title">Research Experience</h2>
+            <div class="card mb-4 shadow-sm">
+              <div class="card-body">
+                <div class="d-flex flex-column flex-md-row justify-content-between">
+                  <div>
+                    <h3 class="h4">Research Assistant • Cardinal Operations</h3>
+                    <p class="text-muted">Shanghai, China • Apr. 2025 – Present</p>
+                  </div>
+                </div>
+                <ul>
+                  <li>Investigating strategies to improve physics-informed neural network training with DRSOM and MUON optimizers.</li>
+                  <li>Exploring Polyak step sizes for training scientific machine learning models.</li>
+                  <li>Proposed a distributionally robust steepest descent method for resilient optimization.</li>
+                  <li>Built an extensible benchmarking repository for comparing optimizers on nanoGPT and CNN workloads.</li>
+                </ul>
+              </div>
+            </div>
+            <div class="card shadow-sm">
+              <div class="card-body">
+                <div class="d-flex flex-column flex-md-row justify-content-between">
+                  <div>
+                    <h3 class="h4">Participant • Mathematics in Lean Workshop</h3>
+                    <p class="text-muted">Department of Mathematics, Peking University • Jan. 2025</p>
+                  </div>
+                </div>
+                <p>Learned to formalize optimization proofs using the Lean theorem prover, strengthening my ability to connect rigorous mathematics with modern verification tools.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="experience" class="py-5">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-10">
+            <h2 class="section-title">Academic &amp; Volunteer Experience</h2>
+            <div class="card mb-4 shadow-sm">
+              <div class="card-body">
+                <h3 class="h4">Teaching Assistant — Higher Algebra</h3>
+                <p class="text-muted">Department of Mathematics, Xi’an Jiaotong University • Sept. 2024 – Jan. 2025</p>
+                <ul>
+                  <li>Designed and led bi-weekly tutorials for more than 50 undergraduate students.</li>
+                  <li>Created solution guides and graded assignments to reinforce conceptual understanding.</li>
+                </ul>
+              </div>
+            </div>
+            <div class="card shadow-sm">
+              <div class="card-body">
+                <h3 class="h4">Teaching Volunteer</h3>
+                <p class="text-muted">School of Journalism and New Media, Xi’an Jiaotong University • Jan. 2024 – Feb. 2024</p>
+                <p>Mentored a 10th-grade student in mathematics, helping her improve from 11,594th to 3,870th in her city-wide ranking.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="honors" class="py-5 bg-light">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-10">
+            <h2 class="section-title">Honors &amp; Awards</h2>
+            <div class="row g-4">
+              <div class="col-md-6">
+                <div class="award-card h-100">
+                  <h3>Top Ten Excellent Student Models</h3>
+                  <p class="text-muted">Xi’an Jiaotong University • 2023 – 2024</p>
+                  <p>Highest undergraduate honor at XJTU (Rank 1/10).</p>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="award-card h-100">
+                  <h3>National Scholarship</h3>
+                  <p class="text-muted">2022 – 2023</p>
+                  <p>Awarded to the top 0.25% of students nationwide.</p>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="award-card h-100">
+                  <h3>Chinese Mathematics Competition</h3>
+                  <p class="text-muted">National 1st Prize • 2022 &amp; 2023</p>
+                  <p>Recognized for excellence in mathematical problem solving.</p>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="award-card h-100">
+                  <h3>S.-T. Yau College Student Mathematics Contest</h3>
+                  <p class="text-muted">2024</p>
+                  <p>Excellence Award in Applied &amp; Computational Mathematics (Global Rank 17) and Excellence Award in Analysis &amp; PDE.</p>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="award-card h-100">
+                  <h3>Chinese Mathematics Competition (Final Round)</h3>
+                  <p class="text-muted">Senior Group • 2024</p>
+                  <p>1<sup>st</sup> Prize in the national finals.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="skills" class="py-5">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-10">
+            <h2 class="section-title">Skills</h2>
+            <div class="row g-4">
+              <div class="col-md-4">
+                <div class="skill-card h-100">
+                  <h3>Programming</h3>
+                  <ul class="mb-0">
+                    <li>Python</li>
+                    <li>MATLAB</li>
+                    <li>C / C++ / C#</li>
+                    <li>LaTeX (including Beamer)</li>
+                  </ul>
+                </div>
+              </div>
+              <div class="col-md-4">
+                <div class="skill-card h-100">
+                  <h3>Languages</h3>
+                  <ul class="mb-0">
+                    <li>English — TOEFL 105</li>
+                    <li>GRE — 322 (V+Q) &amp; 3.0 AWA</li>
+                  </ul>
+                </div>
+              </div>
+              <div class="col-md-4">
+                <div class="skill-card h-100">
+                  <h3>Subject Mastery</h3>
+                  <ul class="mb-0">
+                    <li>GRE Mathematics Subject Test: 970</li>
+                    <li>Advanced undergraduate analysis and algebra</li>
+                    <li>Stochastic processes &amp; optimization</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact" class="py-5 bg-dark text-light">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-8 text-center">
+            <h2 class="section-title text-white">Let’s Connect</h2>
+            <p class="fs-5">I am always excited to discuss optimization, mathematics, and opportunities for collaboration. Feel free to reach out!</p>
+            <div class="contact-info d-flex flex-column flex-sm-row justify-content-center align-items-center gap-3 mt-4">
+              <a class="btn btn-outline-light" href="mailto:tao_hu2358@outlook.com"><i class="bi bi-envelope"></i> tao_hu2358@outlook.com</a>
+              <a class="btn btn-outline-light" href="tel:+8618072990865">+86 180 7299 0865</a>
+              <a class="btn btn-outline-light" href="https://github.com/taohu-hub" target="_blank" rel="noopener">GitHub</a>
+            </div>
+            <p class="mt-4 mb-0">No. 28, West Xianning Road, Xi’an 710049, Shaanxi, China</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="py-4 text-center text-muted">
+    <div class="container">
+      <small>© <span id="year"></span> Tao Hu. Crafted with inspiration from Wanyu Zhang’s portfolio.</small>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Bootstrap-powered personal homepage tailored to Tao Hu's profile
- highlight education, research, teaching, awards, and skills using timeline and card layouts
- apply custom styling inspired by Wanyu Zhang's site, including hero banner and contact section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d55a53a06c8333b4471cad01c50afe