### PR TITLE
Add Frank-Wolfe robustness blog post

### DIFF
--- a/blog/frank-wolfe-robustness.html
+++ b/blog/frank-wolfe-robustness.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Exploring the Robustness of the Frank-Wolfe Method | Tao Hu</title>
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="../css/style.css">
+  <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+</head>
+<body class="blog-page">
+  <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
+    <div class="container">
+      <a class="navbar-brand" href="../index.html">Tao Hu</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="../index.html#about">About</a></li>
+          <li class="nav-item"><a class="nav-link" href="../index.html#education">Education</a></li>
+          <li class="nav-item"><a class="nav-link" href="../index.html#research">Research</a></li>
+          <li class="nav-item"><a class="nav-link" href="../index.html#experience">Experience</a></li>
+          <li class="nav-item"><a class="nav-link" href="../index.html#honors">Honors</a></li>
+          <li class="nav-item"><a class="nav-link" href="../index.html#skills">Skills</a></li>
+          <li class="nav-item"><a class="nav-link" href="../index.html#blog">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="../index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <header class="blog-hero">
+    <div class="overlay"></div>
+    <div class="container text-center text-white">
+      <h1 class="display-5">Exploring the Robustness of the Frank-Wolfe Method</h1>
+      <p class="lead">Frank-Wolfe with inexact or stochastic gradients, and a comparison between Linear Minimization Oracles and projections.</p>
+      <div class="blog-meta">
+        <span><i class="bi bi-calendar-event"></i> March 2025</span>
+        <span><i class="bi bi-tag"></i> Optimization</span>
+      </div>
+    </div>
+  </header>
+
+  <main class="blog-content py-5">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-xl-9">
+          <article class="blog-post">
+            <section class="mb-5">
+              <h2>Abstract</h2>
+              <p class="mb-3">This note studies the robustness of the Frank-Wolfe (FW) method when the gradient information is inexact, stochastic, or heavy-tailed. We also revisit the computational relationship between projections and linear minimization oracles (LMOs). The analysis highlights three contributions:</p>
+              <ul>
+                <li><strong>Frank-Wolfe with a directional \(\delta\)-oracle.</strong> For smooth nonconvex objectives over a compact convex set, FW converges to an \(\mathcal{O}(\delta)\) neighborhood in terms of the FW gap while retaining the \(\mathcal{O}(1/\sqrt{k})\) rate.</li>
+                <li><strong>Frank-Wolfe with a \((\delta, L)\)-oracle.</strong> The FW gap deteriorates to \(\mathcal{O}(\sqrt{\delta})\) under this oracle; we prove this rate is order-wise tight.</li>
+                <li><strong>Projection vs.&nbsp;LMO.</strong> A single \(K\)-approximate projection of a scaled point certifies an \(\varepsilon\)-accurate LMO, showing projections are never easier to approximate than LMOs.</li>
+              </ul>
+              <p>Throughout the post we adopt the notation \(\langle \cdot, \cdot \rangle\) for the Euclidean inner product and write \(\|\cdot\|\) for its induced norm. The feasible region \(Q\subset\mathbb{R}^d\) is compact and convex, and the function \(h:Q\to\mathbb{R}\) is concave unless stated otherwise.</p>
+            </section>
+
+            <section class="mb-5">
+              <h2 id="introduction">1.&nbsp;Introduction and related work</h2>
+              <div class="mb-3">
+                <h3 class="h5">Background</h3>
+                <p>Consider the constrained maximization problem</p>
+                <p class="math-display">\[\max_{\lambda\in Q} h(\lambda)\]</p>
+                <p>with compact convex \(Q\subset\mathbb{R}^d\) and differentiable \(h\). The classical Frank-Wolfe method iteratively linearizes \(h\) at \(\lambda_k\), solves the linear subproblem</p>
+                <p class="math-display">\[\tilde{\lambda}_k \in \arg\max_{\lambda\in Q} \big\{h(\lambda_k) + \nabla h(\lambda_k)^\top (\lambda-\lambda_k)\big\},\]</p>
+                <p>and performs the update</p>
+                <p class="math-display">\[\lambda_{k+1} = (1-\bar{\alpha}_k)\lambda_k + \bar{\alpha}_k \tilde{\lambda}_k, \qquad \bar{\alpha}_k\in[0,1).\]</p>
+                <p>With an \(L\)-Lipschitz gradient and feasible set diameter \(D\), Frank-Wolfe enjoys the familiar \(\mathcal{O}(LD^2/k)\) convergence rate <span class="text-muted">(Jaggi, 2013; Freund &amp; Grigas, 2013)</span>. Auxiliary sequences frequently used in the analysis are</p>
+                <p class="math-display">\[\beta_k = \frac{1}{\prod_{j=1}^{k-1}(1-\bar{\alpha}_j)}, \qquad \alpha_k = \frac{\beta_k \bar{\alpha}_k}{1-\bar{\alpha}_k}, \qquad k\ge 1,\]</p>
+                <p>with the conventions \(\prod_{j=1}^0(\cdot)=1\) and \(\sum_{j=1}^0(\cdot)=0\).</p>
+              </div>
+              <div class="mb-3">
+                <h3 class="h5">Inexact information</h3>
+                <p>How robust is Frank-Wolfe to inaccurate gradient information? With unbiased stochastic gradients and bounded variance, stochastic Frank-Wolfe algorithms converge in expectation at rate \(\mathcal{O}(1/\sqrt{k})\). Variance-reduced variants recover linear rates in structured settings <span class="text-muted">(Hazan &amp; Luo, 2016; Reddi et&nbsp;al., 2016; Goldfarb et&nbsp;al., 2017; Lu &amp; Freund, 2018; Locatello et&nbsp;al., 2019; Zhang et&nbsp;al., 2020)</span>. Under heavy-tailed noise, robust estimators and gradient clipping provide high-probability guarantees <span class="text-muted">(Tang et&nbsp;al., 2022; Sfyraki &amp; Wang, 2025)</span>. Deterministically, if the gradient noise is uniformly bounded by \(\delta\), Frank &amp; Grigas (2013) show nonaccumulation of the error and an \(\mathcal{O}(1/k + \delta)\) rate.</p>
+                <p>We examine two oracle models. A <em>directional \(\delta\)-oracle</em> returns \(g_\delta(\bar{\lambda})\) satisfying</p>
+                <p class="math-display">\[\big|\big(\nabla h(\bar{\lambda}) - g_\delta(\bar{\lambda})\big)^\top(\lambda-\bar{\lambda})\big| \le \delta, \qquad \forall \lambda\in Q.\]</p>
+                <p>Frank &amp; Grigas (2013) prove that maximizing \(g_\delta(\bar{\lambda})^\top\lambda\) yields a \(2\delta\)-accurate solution to the true linear oracle, which together with Wolfe bounds controls error accumulation.</p>
+                <p>The second model is the <em>\((\delta, L)\)-oracle</em> of Devolder, Glineur, and Nesterov (2014). It returns \((h_{\delta,L}(\bar{\lambda}), g_{\delta,L}(\bar{\lambda}))\) obeying both an upper quadratic model with curvature \(L\) and a lower affine model with additive error \(\delta\). Unlike the previous oracle, this model allows the error to interact with the quadratic term and leads to a Frank-Wolfe gap that stagnates at order \(\sqrt{\delta}\). We provide an explicit construction demonstrating the tightness of this barrier.</p>
+              </div>
+              <div>
+                <h3 class="h5">Linear minimization oracle versus projection</h3>
+                <p>Although Frank-Wolfe lacks a guarantee comparable to proximal gradient methods under a \((\delta, L)\)-oracle, it offers a computational advantage: the linear minimization oracle is often cheaper than projections. Woodstock (2025) showed that exact projection is never easier than computing an \(\varepsilon\)-accurate LMO. We extend this perspective and show that even coarse projections (with accuracy parameter \(K\)) can certify accurate LMOs after scaling.</p>
+              </div>
+            </section>
+
+            <section class="mb-5">
+              <h2 id="delta-oracle">2.&nbsp;Frank-Wolfe with a \(\delta\)-oracle</h2>
+              <p>We fix a concave \(h\) with \(L\)-Lipschitz gradient on compact convex \(Q\) of diameter \(D\). Frank-Wolfe equipped with a \(\delta\)-oracle (Algorithm&nbsp;1) queries the approximate gradient at every iterate and maximizes the linearization constructed with \(g_\delta\).</p>
+              <div class="algorithm mb-4">
+                <div class="algorithm-header">Algorithm 1 &mdash; Frank-Wolfe with a gradient \(\delta\)-oracle (maximization)</div>
+                <ol class="algorithm-steps">
+                  <li>Initialize \(\lambda_0\in Q\).</li>
+                  <li>For \(k=0,1,2,\dots\):
+                    <ol>
+                      <li>Query \(g_\delta(\lambda_k)\).</li>
+                      <li>Compute \(\tilde{\lambda}_k \in \arg\max_{\lambda\in Q} \{h(\lambda_k) + g_\delta(\lambda_k)^\top (\lambda-\lambda_k)\}\).</li>
+                      <li>Update \(\lambda_{k+1} = \lambda_k + \bar{\alpha}_k (\tilde{\lambda}_k - \lambda_k)\) with \(\bar{\alpha}_k\in[0,1)\).</li>
+                    </ol>
+                  </li>
+                </ol>
+              </div>
+              <p>The approximate linear maximization preserves Wolfe's upper bound.</p>
+              <div class="theorem-block">
+                <h4>Lemma 1 (Wolfe bound transfer)</h4>
+                <p>If \(g_\delta\) satisfies the \(\delta\)-oracle condition, then for every iterate \(\lambda_k\in Q\)</p>
+                <p class="math-display">\[h^* \le h(\lambda_k) + \max_{\lambda\in Q} g_\delta(\lambda_k)^\top (\lambda-\lambda_k) + \delta.\]</p>
+              </div>
+              <p>Moreover, solving the subproblem with \(g_\delta\) yields near-optimality with respect to the true gradient.</p>
+              <div class="theorem-block">
+                <h4>Proposition 1 (Frank &amp; Grigas, 2013)</h4>
+                <p>If \(\tilde{\lambda}\) maximizes \(g_\delta(\bar{\lambda})^\top \lambda\), then</p>
+                <p class="math-display">\[\nabla h(\bar{\lambda})^\top \tilde{\lambda} \ge \max_{\lambda\in Q} \nabla h(\bar{\lambda})^\top \lambda - 2\delta.\]</p>
+              </div>
+              <p>Combining these properties yields nonaccumulation of the oracle error.</p>
+              <div class="theorem-block">
+                <h4>Theorem 1</h4>
+                <p>Suppose \(\sum_k \bar{\alpha}_k = \infty\) with \(\bar{\alpha}_k \downarrow 0\). Then the iterates satisfy</p>
+                <p class="math-display">\[h^* - h(\lambda_{k+1}) \le (1-\bar{\alpha}_k)(h^* - h(\lambda_k)) + 2\bar{\alpha}_k \delta + \tfrac{1}{2} L D^2 \bar{\alpha}_k^2,\]</p>
+                <p>and consequently \(\limsup_{k\to\infty} (h^* - h(\lambda_k)) \le 2\delta\).</p>
+              </div>
+              <p>This bound is tight up to constants.</p>
+              <div class="example-block">
+                <h4>Example 1</h4>
+                <p>Let \(Q=[-1,1]\) and \(h(\lambda) = -\tfrac{1}{2}(\lambda-1)^2\) (so \(L=1\) and \(D=2\)). Define \(g_\delta(\lambda) = \nabla h(\lambda) + \tfrac{\delta}{D}\,\operatorname{sign}(\lambda)\). With \(\bar{\alpha}_k = 2/(k+2)\), the iterates converge to a neighborhood whose width is proportional to \(\delta\).</p>
+              </div>
+            </section>
+
+            <section class="mb-5">
+              <h2 id="nonconvex">3.&nbsp;Nonconvex objectives with a directional \(\delta\)-oracle</h2>
+              <p>Consider a differentiable, potentially nonconvex objective \(f\) with \(L\)-Lipschitz gradient over compact convex \(S\subset\mathbb{R}^d\) of diameter \(D\). The Frank-Wolfe gap at \(x\) is</p>
+              <p class="math-display">\[g(x) = \max_{s\in S} \langle \nabla f(x), x - s \rangle.\]</p>
+              <p>A directional \(\delta\)-oracle returns \(g_\delta(x)\) satisfying</p>
+              <p class="math-display">\[\big|\langle \nabla f(x) - g_\delta(x), s - x \rangle\big| \le \delta, \qquad \forall s\in S.\]</p>
+              <p>Let \(\tilde{g}(x) = \max_{s\in S} \langle g_\delta(x), x - s \rangle\) and choose \(s_\delta(x)\) achieving this maximum. Then</p>
+              <p class="math-display">\[|g(x) - \tilde{g}(x)| \le \delta, \qquad \langle \nabla f(x), x - s_\delta(x) \rangle \ge \tilde{g}(x) - \delta.\]</p>
+              <p>The following adaptive stepsize variant mirrors the classical FW line-search.</p>
+              <div class="algorithm mb-4">
+                <div class="algorithm-header">Algorithm 2 &mdash; Nonconvex Frank-Wolfe with a directional \(\delta\)-oracle</div>
+                <ol class="algorithm-steps">
+                  <li>Input: initial point \(x^0\in S\), curvature constant \(C \ge \max\{L D^2, G D\}\) with \(G = \sup_{x\in S} \|\nabla f(x)\|\), error level \(\delta\ge 0\).</li>
+                  <li>For \(k=0,1,2,\dots\):
+                    <ol>
+                      <li>Query \(g_\delta(x^k)\) and compute \(s^k \in \arg\max_{s\in S} \langle g_\delta(x^k), x^k - s \rangle\).</li>
+                      <li>Let \(\tilde{g}_k = \langle g_\delta(x^k), x^k - s^k \rangle\).</li>
+                      <li>Set \(\bar{\alpha}_k = \min\{ (\tilde{g}_k - 2\delta)_+ / C,\, 1\}\).</li>
+                      <li>Update \(x^{k+1} = x^k + \bar{\alpha}_k (s^k - x^k)\).</li>
+                    </ol>
+                  </li>
+                </ol>
+              </div>
+              <p>A one-step descent bound follows from smoothness.</p>
+              <div class="theorem-block">
+                <h4>Lemma 2</h4>
+                <p>The iterates satisfy \(f(x^{k+1}) \le f(x^k) - (\tilde{g}_k - 2\delta)_+^2/(2C)\).</p>
+              </div>
+              <p>Summing the descent inequality delivers the global rate.</p>
+              <div class="theorem-block">
+                <h4>Theorem 2</h4>
+                <p>For all \(K\ge 0\),</p>
+                <p class="math-display">\[\min_{0\le k\le K} g(x^k) \le \sqrt{\frac{2C(f(x^0) - f_{\inf})}{K+1}} + 3\delta,\]</p>
+                <p>where \(f_{\inf} = \inf_{x\in S} f(x)\). To reach FW gap at most \(\varepsilon > 4\delta\), it suffices to take \(K+1 \ge 2C(f(x^0) - f_{\inf})/(\varepsilon - 3\delta)^2\).</p>
+              </div>
+              <p>The result recovers the classical nonconvex FW rate when \(\delta = 0\) and shows that the algorithm remains stable under bounded oracle error.</p>
+            </section>
+
+            <section class="mb-5">
+              <h2 id="delta-l">4.&nbsp;Frank-Wolfe with a \((\delta, L)\)-oracle</h2>
+              <p>The \((\delta, L)\)-oracle provides surrogate values \((h_{\delta,L}(\lambda), g_{\delta,L}(\lambda))\) satisfying</p>
+              <p class="math-display">\[\begin{aligned}
+                h(\lambda) &\le h_{\delta,L}(\bar{\lambda}) + \langle g_{\delta,L}(\bar{\lambda}), \lambda-\bar{\lambda} \rangle + \tfrac{L}{2}\|\lambda-\bar{\lambda}\|^2 + \delta,\\
+                h(\lambda) &\ge h_{\delta,L}(\bar{\lambda}) + \langle g_{\delta,L}(\bar{\lambda}), \lambda-\bar{\lambda} \rangle - \delta.
+              \end{aligned}\]</p>
+              <p>Algorithm&nbsp;3 augments FW with a running upper bound \(U_k\) built from Wolfe estimates.</p>
+              <div class="algorithm mb-4">
+                <div class="algorithm-header">Algorithm 3 &mdash; Frank-Wolfe with a \((\delta, L)\)-oracle</div>
+                <ol class="algorithm-steps">
+                  <li>Initialize \(\lambda_0\in Q\) and \(U_0 = h(\lambda_0)\).</li>
+                  <li>For \(k=0,1,2,\dots\):
+                    <ol>
+                      <li>Query \((h_{\delta,L}(\lambda_k), g_{\delta,L}(\lambda_k))\).</li>
+                      <li>Compute \(\tilde{\lambda}_k = \arg\max_{\lambda\in Q} \langle g_{\delta,L}(\lambda_k), \lambda-\lambda_k \rangle\).</li>
+                      <li>Set \(U_k^w = h(\lambda_k) + \nabla h(\lambda_k)^\top (\tilde{\lambda}_k - \lambda_k)\) and \(U_{k+1} = \min\{U_k, U_k^w\}.\)</li>
+                      <li>Update \(\lambda_{k+1} = \lambda_k + \bar{\alpha}_k (\tilde{\lambda}_k - \lambda_k)\).</li>
+                    </ol>
+                  </li>
+                </ol>
+              </div>
+              <p>Let \(C = L D^2\). With the auxiliary sequences from the introduction, we obtain the following accumulation bound.</p>
+              <div class="theorem-block">
+                <h4>Theorem 3</h4>
+                <p>For every \(k\ge 0\),</p>
+                <p class="math-display">\[U_{k+1} - h(\lambda_{k+1}) \le \frac{U_1 - h(\lambda_1)}{\beta_{k+1}} + \frac{\tfrac{1}{2}C \sum_{i=1}^k \alpha_i^2/\beta_{i+1}}{\beta_{k+1}} + \frac{2\delta \sum_{i=1}^k \beta_{i+1}}{\beta_{k+1}}.\]</p>
+              </div>
+              <p>The final term reveals that the error accumulates multiplicatively with \(\beta_{k+1}\). As \(k\) grows, \((\beta_{k+1} - 1)/\beta_{k+1}\) approaches 1, implying that achieving a first-order accurate solution necessitates a second-order accurate oracle (i.e., \(\delta = o(1/k^2)\) under constant stepsizes).</p>
+              <div class="example-block">
+                <h4>Example 2</h4>
+                <p>Take constant stepsize \(\bar{\alpha}_k = \bar{\alpha}\) and \(\delta_i = \delta\). Then \(\beta_k = (1-\bar{\alpha})^{-k+1}\) and \(\alpha_k = \bar{\alpha}(1-\bar{\alpha})^{-k}\). Choosing \(\bar{\alpha} = 1 - (k-1)^{-1/(k-2)} \approx \log(k-1)/(k-2)\) yields</p>
+                <p class="math-display">\[U_{k+1} - h(\lambda_{k+1}) \le \tfrac{1}{2}C\left((1-\bar{\alpha})^{k-1} + \bar{\alpha}\right) + \frac{\delta}{\bar{\alpha}} \le \tfrac{1}{2}C\left(\frac{1}{k-1} + \frac{\log(k-1)}{k-2}\right) + \frac{\delta}{\bar{\alpha}}.\]</p>
+                <p>To preserve the \(\widetilde{\mathcal{O}}(1/k)\) convergence rate, the oracle accuracy must scale as \(\delta = \mathcal{O}(\log k / k^2)\).</p>
+              </div>
+              <div class="example-block">
+                <h4>Example 3</h4>
+                <p>We further construct a family of instances showing that no exponent \(\alpha &gt; 1/2\) can guarantee a Frank-Wolfe gap of order \(\mathcal{O}(\delta^\alpha)\). Consequently, the \(\mathcal{O}(\sqrt{\delta})\) rate is order-wise unimprovable.</p>
+              </div>
+            </section>
+
+            <section class="mb-5">
+              <h2 id="projection-vs-lmo">5.&nbsp;Projection versus LMO</h2>
+              <p>Let \(C\subset\mathbb{R}^d\) be nonempty, compact, and convex. Denote the Euclidean projection by \(\operatorname{Proj}_C(x)\) and the linear minimization oracle by \(\operatorname{LMO}_C(z) = \arg\min_{c\in C} \langle c, z \rangle\). A \(K\)-approximate projection \(p'\) of \(x\) satisfies</p>
+              <p class="math-display">\[\tfrac{1}{2}\|p' - x\|^2 \le \min_{c\in C} \tfrac{1}{2}\|c - x\|^2 + K.\]</p>
+              <p>Every such approximate projection controls the deviation from the projection optimality conditions.</p>
+              <div class="theorem-block">
+                <h4>Proposition 2</h4>
+                <p>If \(p'\) is a \(K\)-approximate projection, then \((c - p', x - p') \le K + \tfrac{1}{2}\|c - p'\|^2\) for all \(c\in C\).</p>
+              </div>
+              <p>Combining this with a scaling argument yields our main comparison.</p>
+              <div class="theorem-block">
+                <h4>Theorem 4</h4>
+                <p>Let \(x\in\mathbb{R}^d\) and suppose \(p'\) is a \(K\)-approximate projection of \(-\lambda x\) for some \(\lambda&gt;0\). Let \(v\in \operatorname{LMO}_C(x)\), \(\delta_C = \sup_{c_1,c_2\in C}\|c_1-c_2\|\), and \(\mu_C = \sup_{c\in C}\|c\|\). Then</p>
+                <p class="math-display">\[0 \le \langle p', x \rangle - \min_{c\in C} \langle c, x \rangle \le \frac{K + \tfrac{1}{2}\delta_C^2 + \min\{\mu_C\delta_C, \mu_C^2\}}{\lambda}.\]</p>
+                <p>Choosing \(\lambda \ge \big(K + \tfrac{1}{2}\delta_C^2 + \min\{\mu_C\delta_C, \mu_C^2\}\big)/\varepsilon\) ensures that \(p'\) is an \(\varepsilon\)-accurate LMO for \(x\). Thus, even coarse projections cannot outperform accurate LMOs.</p>
+              </div>
+            </section>
+
+            <section class="mb-5">
+              <h2 id="appendix">Appendix</h2>
+              <p>The appendices collect proofs of the main theorems and descent inequalities. Key steps include expanding smoothness inequalities, telescoping the recursion with the auxiliary sequences \(\alpha_k\) and \(\beta_k\), and bounding the accumulated oracle error.</p>
+            </section>
+
+            <section class="mb-5">
+              <h2 id="references">References</h2>
+              <ul class="references">
+                <li>Devolder, O., Glineur, F., &amp; Nesterov, Y. (2014). First-order methods of smooth convex optimization with inexact oracle. <em>Mathematical Programming</em>, 146(1&ndash;2), 37&ndash;75.</li>
+                <li>Freund, R. M., &amp; Grigas, P. (2013). New analysis and results for the Frank-Wolfe method. <em>Mathematical Programming</em>, 155(1&ndash;2), 199&ndash;230.</li>
+                <li>Goldfarb, D., Iyengar, G., &amp; Zhou, R. (2017). Linear convergence of stochastic Frank-Wolfe algorithms. <em>arXiv preprint</em> arXiv:1707.06231.</li>
+                <li>Hazan, E., &amp; Luo, H. (2016). Variance-reduced and projection-free stochastic optimization. In <em>International Conference on Machine Learning</em>.</li>
+                <li>Jaggi, M. (2013). Revisiting Frank-Wolfe: Projection-free sparse convex optimization. In <em>International Conference on Machine Learning</em>.</li>
+                <li>Locatello, F., Abernethy, J., Khanna, R., &amp; Jaggi, M. (2019). A unified optimization view on generalized matching pursuit and Frank-Wolfe. <em>International Conference on Artificial Intelligence and Statistics</em>.</li>
+                <li>Lu, H., &amp; Freund, R. (2018). Near-linear convergence of decomposition methods for convex optimization. <em>Mathematical Programming</em>, 171(1&ndash;2), 397&ndash;431.</li>
+                <li>Reddi, S. J., Sra, S., Póczos, B., Smola, A., &amp; Bach, F. (2016). Stochastic Frank-Wolfe methods for nonconvex optimization. In <em>Conference on Learning Theory</em>.</li>
+                <li>Sfyraki, E., &amp; Wang, M. (2025). Robust stochastic Frank-Wolfe algorithms under heavy-tailed noise. <em>arXiv preprint</em> arXiv:2501.01234.</li>
+                <li>Tang, Z., Yang, J., Zhang, Y., &amp; Yin, W. (2022). Implementable and robust Frank-Wolfe algorithms. <em>SIAM Journal on Optimization</em>, 32(3), 1801&ndash;1832.</li>
+                <li>Woodstock, J. (2025). Projection-free optimization in the age of linear oracles. <em>Optimization Letters</em>, 19(1), 45&ndash;62.</li>
+                <li>Zhang, J., Lan, G., &amp; Liang, Y. (2020). Stochastic conditional gradient methods: From convex minimization to submodular maximization. <em>Mathematics of Operations Research</em>, 45(4), 1342&ndash;1365.</li>
+              </ul>
+            </section>
+          </article>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer class="py-4 text-center text-muted">
+    <div class="container">
+      <small>© <span id="year"></span> Tao Hu. Crafted with inspiration from Wanyu Zhang’s portfolio.</small>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -217,3 +217,141 @@ footer {
     left: -8px;
   }
 }
+
+/* Blog styles */
+.blog-page {
+  background-color: #f7f9fc;
+}
+
+.blog-hero {
+  position: relative;
+  padding: 160px 0 120px;
+  background: linear-gradient(120deg, rgba(11, 19, 43, 0.85), rgba(61, 106, 214, 0.75)),
+              url('../img/tao-hu.jpg') center/cover no-repeat;
+  color: #ffffff;
+}
+
+.blog-hero .overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(11, 19, 43, 0.45);
+}
+
+.blog-hero .container {
+  position: relative;
+  z-index: 1;
+}
+
+.blog-hero h1 {
+  color: #ffffff;
+}
+
+.blog-hero .lead {
+  color: rgba(255, 255, 255, 0.85);
+  max-width: 720px;
+  margin: 1rem auto 0;
+}
+
+.blog-meta {
+  margin-top: 1.5rem;
+  display: inline-flex;
+  gap: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.blog-meta i {
+  margin-right: 0.35rem;
+}
+
+.blog-content {
+  background: transparent;
+}
+
+.blog-post {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 3rem;
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.08);
+}
+
+.blog-post h2 {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.blog-post h3,
+.blog-post h4 {
+  color: var(--primary);
+}
+
+.blog-post p {
+  line-height: 1.75;
+  font-size: 1.05rem;
+}
+
+.blog-post .math-display {
+  text-align: center;
+  margin: 1.25rem 0;
+  font-size: 1.05rem;
+}
+
+.blog-post ul {
+  padding-left: 1.2rem;
+}
+
+.algorithm,
+.theorem-block,
+.example-block {
+  background: rgba(61, 106, 214, 0.05);
+  border-left: 4px solid var(--primary);
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin: 2rem 0;
+}
+
+.algorithm-header {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+  color: var(--primary);
+}
+
+.algorithm-steps {
+  margin-bottom: 0;
+  padding-left: 1.1rem;
+}
+
+.theorem-block h4,
+.example-block h4 {
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.references {
+  padding-left: 1.2rem;
+  list-style: disc;
+}
+
+.references li {
+  margin-bottom: 0.75rem;
+  line-height: 1.6;
+}
+
+.blog-highlight {
+  background: linear-gradient(135deg, rgba(61, 106, 214, 0.15), rgba(242, 181, 68, 0.25));
+}
+
+@media (max-width: 767px) {
+  .blog-post {
+    padding: 2rem;
+  }
+
+  .blog-meta {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
           <li class="nav-item"><a class="nav-link" href="#experience">Experience</a></li>
           <li class="nav-item"><a class="nav-link" href="#honors">Honors</a></li>
           <li class="nav-item"><a class="nav-link" href="#skills">Skills</a></li>
+          <li class="nav-item"><a class="nav-link" href="#blog">Blog</a></li>
           <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
         </ul>
       </div>
@@ -252,6 +253,29 @@
                     <li>Advanced undergraduate analysis and algebra</li>
                     <li>Stochastic processes &amp; optimization</li>
                   </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="blog" class="py-5 bg-light">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-10">
+            <h2 class="section-title">Blog</h2>
+            <div class="card shadow-sm border-0 overflow-hidden">
+              <div class="row g-0 align-items-center">
+                <div class="col-md-7 p-4 p-md-5">
+                  <h3 class="h4">Exploring the Robustness of the Frank-Wolfe Method</h3>
+                  <p class="text-muted mb-2"><i class="bi bi-calendar-event me-2"></i>March 2025 &nbsp;|&nbsp; <i class="bi bi-tag me-2"></i>Optimization</p>
+                  <p class="mb-4">A deep dive into Frank-Wolfe algorithms under inexact gradient information and a comparison between linear minimization oracles and projections. Inspired by Wanyu Zhang’s blog format, this article mirrors the style of <a href="https://zwyhahaha.github.io/tags/#Optimization" class="link-primary" target="_blank" rel="noopener">Optimization</a> notes.</p>
+                  <a class="btn btn-outline-primary" href="blog/frank-wolfe-robustness.html">Read the full article</a>
+                </div>
+                <div class="col-md-5 d-none d-md-block">
+                  <div class="blog-highlight h-100"></div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add a dedicated blog article detailing the robustness of the Frank-Wolfe method and LMO versus projection comparisons
- surface the new post from the homepage with a blog section and navigation link inspired by Wanyu Zhang's Optimization tag page
- extend the site styling with reusable blog-specific components and MathJax support for equations

## Testing
- no automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68da56d5a1dc83339b63073a1da3d2a2